### PR TITLE
Fixing Warning during compilation due to int and std::size_t comparis…

### DIFF
--- a/src/StreamReader.cpp
+++ b/src/StreamReader.cpp
@@ -151,7 +151,7 @@ bool StreamReader::readid_ok(unsigned int readId) const
     return readId == readId_;
 }
 
-void StreamReader::timeout_reached(unsigned int readId, const ErrorCode& err)
+void StreamReader::timeout_reached(unsigned int readId, const ErrorCode& /*err*/)
 {
     if(!readid_ok(readId)) {
         return;
@@ -181,7 +181,7 @@ void StreamReader::do_read_some(std::size_t count, uint8_t* data,
         // readBuffer_ not empty
         std::istream is(&readBuffer_);
         char c = is.get();
-        int readCount = 0;
+        std::size_t readCount = 0;
         while(!is.eof() && readCount < count) {
             data[readCount] = c;
             readCount++;
@@ -275,7 +275,7 @@ std::size_t StreamReader::read(std::size_t count, uint8_t* data,
     return processed_;
 }
 
-void StreamReader::read_callback(const ErrorCode& err, std::size_t readCount)
+void StreamReader::read_callback(const ErrorCode& /*err*/, std::size_t /*readCount*/)
 {
     // finish read was already called through the async_read primitive
     waiterNotified_ = true;
@@ -329,14 +329,14 @@ void StreamReader::async_read_until_continue(unsigned int readId,
     }
 
     const uint8_t* data = dst_ + processed_;
-    int i = 0;
+    std::size_t i = 0;
     for(; i < readCount; i++) {
         if(data[i] == delimiter) {
             // delimiter was found. Saving remaining data in readBuffer_
             i++;
             std::ostream os(&readBuffer_);
             unsigned int toBeCommited = 0;
-            for(int j = i; j < readCount; j++) {
+            for(std::size_t j = i; j < readCount; j++) {
                 os << data[j];
                 toBeCommited++;
             }


### PR DESCRIPTION
Fixing two warning types :
- int / std::size_t comparison 
- unused parameters in functions (A way to avoid warnings is to comment the argument name instead of removing it to keep the API intact) 