### PR TITLE
Fixing unused parameters

### DIFF
--- a/src/AsyncService.cpp
+++ b/src/AsyncService.cpp
@@ -42,7 +42,7 @@ AsyncService::~AsyncService()
     this->stop();
 }
 
-void AsyncService::timer_callback(const ErrorCode& err) const
+void AsyncService::timer_callback(const ErrorCode& /*err*/) const
 {
     //std::cout << "==== Worker timeout guard ====" << std::endl;
     timer_.expires_from_now(Millis(1000));

--- a/src/StreamWriter.cpp
+++ b/src/StreamWriter.cpp
@@ -149,7 +149,7 @@ bool StreamWriter::writeid_ok(unsigned int writeId) const
     return writeId == writeId_;
 }
 
-void StreamWriter::timeout_reached(unsigned int writeId, const ErrorCode& err)
+void StreamWriter::timeout_reached(unsigned int writeId, const ErrorCode& /*err*/)
 {
     if(!writeid_ok(writeId)) {
         return;
@@ -249,7 +249,7 @@ std::size_t StreamWriter::write(std::size_t count, const uint8_t* data,
     return processed_;
 }
 
-void StreamWriter::write_callback(const ErrorCode& err, std::size_t writtenCount)
+void StreamWriter::write_callback(const ErrorCode& /*err*/, std::size_t /*writtenCount*/)
 {
     // finish write was already called through the async_write primitive
     waiterNotified_ = true;

--- a/tests/src/async_read_until.cpp
+++ b/tests/src/async_read_until.cpp
@@ -8,7 +8,7 @@ using namespace rtac::asio;
 
 std::string msg = "Hello there !\n";
 
-void write_callback(const SerialStream::ErrorCode& err,
+void write_callback(const SerialStream::ErrorCode& /*err*/,
                     std::size_t writeCount)
 {
     std::cout << "Wrote data (" << writeCount << " bytes)." << std::endl;
@@ -16,12 +16,12 @@ void write_callback(const SerialStream::ErrorCode& err,
 
 void read_callback(Stream::Ptr stream,
                    std::string* data,
-                   const SerialStream::ErrorCode& err,
+                   const SerialStream::ErrorCode& /*err*/,
                    std::size_t count)
 {
     if(count > 0) {
         std::cout << "Got data (" << count << " bytes) : '";
-        for(int i = 0; i < count; i++) {
+        for(std::size_t i = 0; i < count; i++) {
             std::cout << (*data)[i];
         }
         std::cout << "'" << std::endl;

--- a/tests/src/async_rw.cpp
+++ b/tests/src/async_rw.cpp
@@ -9,7 +9,7 @@ using namespace rtac::asio;
 
 std::string msg = "Hello there !\n";
 
-void write_callback(const SerialStream::ErrorCode& err,
+void write_callback(const SerialStream::ErrorCode& /*err*/,
                     std::size_t writeCount)
 {
     std::cout << "Wrote data (" << writeCount << " bytes)." << std::endl;
@@ -17,12 +17,12 @@ void write_callback(const SerialStream::ErrorCode& err,
 
 void read_callback(Stream::Ptr stream,
                    std::string* data,
-                   const SerialStream::ErrorCode& err,
+                   const SerialStream::ErrorCode& /*err*/,
                    std::size_t count)
 {
     if(count > 0) {
         std::cout << "Got data (" << count << " bytes) : '";
-        for(int i = 0; i < count; i++) {
+        for(std::size_t i = 0; i < count; i++) {
             std::cout << (*data)[i];
         }
         std::cout << "'" << std::endl;

--- a/tests/src/async_rw_some.cpp
+++ b/tests/src/async_rw_some.cpp
@@ -8,7 +8,7 @@ using namespace rtac::asio;
 
 std::string msg = "Hello there !\n";
 
-void write_callback(const SerialStream::ErrorCode& err,
+void write_callback(const SerialStream::ErrorCode& /*err*/,
                     std::size_t writeCount)
 {
     std::cout << "Wrote data (" << writeCount << " bytes)." << std::endl;
@@ -16,11 +16,11 @@ void write_callback(const SerialStream::ErrorCode& err,
 
 void read_callback(Stream::Ptr stream,
                    std::string* data,
-                   const SerialStream::ErrorCode& err,
+                   const SerialStream::ErrorCode& /*err*/,
                    std::size_t count)
 {
     std::cout << "Got data (" << count << " bytes) : ";
-    for(int i = 0; i < count; i++) {
+    for(std::size_t i = 0; i < count; i++) {
         cout << (*data)[i];
     }
     cout << endl << flush;

--- a/tests/src/single_thread.cpp
+++ b/tests/src/single_thread.cpp
@@ -9,7 +9,7 @@ using namespace rtac::asio;
 
 std::string msg = "Hello there !\n";
 
-void write_callback(const SerialStream::ErrorCode& err,
+void write_callback(const SerialStream::ErrorCode& /*err*/,
                     std::size_t writeCount)
 {
     std::cout << "Wrote data (" << writeCount << " bytes)." << std::endl;
@@ -17,12 +17,12 @@ void write_callback(const SerialStream::ErrorCode& err,
 
 void read_callback(Stream::Ptr stream,
                    std::string* data,
-                   const SerialStream::ErrorCode& err,
+                   const SerialStream::ErrorCode& /*err*/,
                    std::size_t count)
 {
     if(count > 0) {
         std::cout << "Got data (" << count << " bytes) : '";
-        for(int i = 0; i < count; i++) {
+        for(std::size_t i = 0; i < count; i++) {
             std::cout << (*data)[i];
         }
         std::cout << "'" << std::endl;

--- a/tests/src/sync_rw.cpp
+++ b/tests/src/sync_rw.cpp
@@ -8,7 +8,7 @@ using namespace rtac::asio;
 
 std::string msg = "Hello there !\n";
 
-void write_callback(const SerialStream::ErrorCode& err,
+void write_callback(const SerialStream::ErrorCode& /*err*/,
                     std::size_t writeCount)
 {
     std::cout << "Wrote data (" << writeCount << " bytes)." << std::endl;

--- a/tests/src/tcp_client01.cpp
+++ b/tests/src/tcp_client01.cpp
@@ -37,11 +37,11 @@ using namespace rtac::asio;
 
 void read_callback(Stream::Ptr stream,
                    std::vector<uint8_t>* data,
-                   const Stream::ErrorCode& err,
+                   const Stream::ErrorCode& /*err*/,
                    std::size_t readCount)
 {
     if(readCount > 0) {
-        for(int i = 0; i < readCount; i++) {
+        for(std::size_t i = 0; i < readCount; i++) {
             cout << (*data)[i];
         }
     }


### PR DESCRIPTION
Fixing unused parameters and std::size_t / int comparison problems when compiling with "-Wall -Wextra -pedantic -Werror"